### PR TITLE
Set macOS deployment target to 10.10

### DIFF
--- a/Sources/WFOAuth2/include/WFOAuth2/WFOAuth2.h
+++ b/Sources/WFOAuth2/include/WFOAuth2/WFOAuth2.h
@@ -16,8 +16,3 @@
 #import <WFOAuth2/WFSlackOAuth2SessionManager.h>
 #import <WFOAuth2/WFUberOAuth2SessionManager.h>
 #import <WFOAuth2/WFSquareOAuth2SessionManager.h>
-
-#ifdef SWIFT_CLASS_EXTRA
-#import <WFOAuth2/NSMutableURLRequest+WFOAuth2.h>
-#import <WFOAuth2/WFOAuth2SessionManagerPrivate.h>
-#endif

--- a/WFOAuth2.xcodeproj/project.pbxproj
+++ b/WFOAuth2.xcodeproj/project.pbxproj
@@ -196,12 +196,12 @@
 		D0B8F7CC1CA89ED7006B1E0D /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0B8F7CE1CA89ED7006B1E0D /* WFOAuth2CredentialTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WFOAuth2CredentialTests.m; sourceTree = "<group>"; };
 		D0B8F7D01CA89ED7006B1E0D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D0B8F7EA1CA8B842006B1E0D /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D0B8F7F71CA8B845006B1E0D /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0B8F7D81CA89F62006B1E0D /* Tests-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Tests-iOS.xcconfig"; sourceTree = "<group>"; };
 		D0B8F7D91CA89F62006B1E0D /* Tests-Mac.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Tests-Mac.xcconfig"; sourceTree = "<group>"; };
 		D0B8F7DA1CA89F62006B1E0D /* Tests-tvOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Tests-tvOS.xcconfig"; sourceTree = "<group>"; };
 		D0B8F7DC1CA89F62006B1E0D /* Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Tests.xcconfig; sourceTree = "<group>"; };
+		D0B8F7EA1CA8B842006B1E0D /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D0B8F7F71CA8B845006B1E0D /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0B8F80A1CA8BBA2006B1E0D /* WFUberOAuth2SessionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WFUberOAuth2SessionManager.h; path = include/WFOAuth2/WFUberOAuth2SessionManager.h; sourceTree = "<group>"; };
 		D0B8F80B1CA8BBA2006B1E0D /* WFUberOAuth2SessionManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WFUberOAuth2SessionManager.m; sourceTree = "<group>"; };
 		D0B8F8141CA8C2D0006B1E0D /* WFOAuth2Defines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WFOAuth2Defines.h; path = include/WFOAuth2/WFOAuth2Defines.h; sourceTree = "<group>"; };
@@ -938,6 +938,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D084DA521CA493C600F92933 /* WFOAuth2-Mac.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 			};
 			name = Debug;
 		};
@@ -945,6 +946,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D084DA521CA493C600F92933 /* WFOAuth2-Mac.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Note that this also removes the imports of two private headers from the umbrella header. See https://github.com/DeskConnect/WFOAuth2/issues/8.